### PR TITLE
feat: use release binaries for warp image

### DIFF
--- a/.github/workflows/WarpPlus-Docker-Selfhosted.yml
+++ b/.github/workflows/WarpPlus-Docker-Selfhosted.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 🌐 Install deps
         run: |
           sudo timedatectl set-timezone Europe/Moscow
-          sudo apt-get update && sudo apt-get install -y jq curl git tree
+          sudo apt-get update && sudo apt-get install -y jq curl git tree tar
 
       - uses: actions/checkout@v4
         with:
@@ -111,15 +111,6 @@ jobs:
           echo "skip=$skip"
           echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
-      - name: 📥 Clone upstream source to WORKDIR
-        if: ${{ steps.check.outputs.skip != 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          rm -rf "${{ env.WORKDIR }}"
-          git clone --depth 1 --branch "${{ steps.check.outputs.repo_tag }}" "${{ env.REPO_EXT_URL }}" "${{ env.WORKDIR }}"
-          echo "Upstream cloned to ${{ env.WORKDIR }}"
-          ls -la "${{ env.WORKDIR }}"
 
   build:
     needs: prepare
@@ -157,48 +148,15 @@ jobs:
         run: |
           mkdir -p "${{ env.ARTIFACT_DIR }}" "${{ env.TAR_DIR }}"
 
-      - name: 📥 Clone upstream source (in build job)
-        if: ${{ needs.prepare.outputs.skip != 'true' }}
+      - name: 📥 Download release archive
         shell: bash
         run: |
           set -euo pipefail
-          rm -rf "${{ env.WORKDIR }}"
-          git clone --depth 1 --branch "${{ needs.prepare.outputs.repo_tag }}" \
-            "${{ env.REPO_EXT_URL }}" "${{ env.WORKDIR }}"
-          echo "Cloned to ${{ env.WORKDIR }}"
-          ls -la "${{ env.WORKDIR }}"
-
-      - name: 🔎 Debug paths
-        shell: bash
-        run: |
-          set -euxo pipefail
-          pwd
-          ls -la
-          ls -la bin || true
-          ls -la bin/warp || true
-
-      - name: 🧩 Copy upstream code into root for Docker context
-        shell: bash
-        run: |
-          set -euo pipefail
-          [ -d "${{ env.WORKDIR }}" ] || { echo "❌ WORKDIR not found"; exit 1; }
-          shopt -s dotglob
-          cp -r "${{ env.WORKDIR }}"/* .
-
-      - name: 🛠️ Replace Dockerfile & scripts
-        shell: bash
-        run: |
-          set -euo pipefail
-          SRC="./bin/warp"
-          [ -f "${SRC}/Dockerfile" ] && install -m 0644 "${SRC}/Dockerfile" Dockerfile || true
-          [ -f "${SRC}/DockerEntrypoint.sh" ] && install -m 0755 "${SRC}/DockerEntrypoint.sh" DockerEntrypoint.sh || true
-          [ -f "${SRC}/config.json.template" ] && install -m 0644 "${SRC}/config.json.template" config.json.template || true
-
-      - name: 📄 Verify Dockerfile exists
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ -f "Dockerfile" ]] || { echo "❌ Dockerfile not found!" >&2; exit 1; }
+          url="https://github.com/${{ env.REPO_EXT_NAME }}/releases/download/${{ needs.prepare.outputs.repo_tag }}/warp-plus_${{ needs.prepare.outputs.repo_tag }}_linux_amd64.tar.gz"
+          curl -L -o warp.tar.gz "$url"
+          sha256sum warp.tar.gz
+          tar -xzf warp.tar.gz -C bin/warp warp-plus warp-scan
+          rm warp.tar.gz
 
       - name: 🔐 DockerHub Login (retry)
         shell: bash
@@ -227,7 +185,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           builder:   ${{ steps.buildx.outputs.name }}
-          context:   .
+          context:   ./bin/warp
+          file:      ./bin/warp/Dockerfile
+          build-args: |
+            WARP_VERSION=${{ needs.prepare.outputs.repo_tag }}
           platforms: ${{ steps.platforms.outputs.platforms }}
           push:      true
           tags: |

--- a/bin/warp/Dockerfile
+++ b/bin/warp/Dockerfile
@@ -1,30 +1,19 @@
-# --- stage: build ---
-ARG GO_VERSION=1.24
-FROM golang:${GO_VERSION}-bookworm AS build
-
-WORKDIR /src
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
-RUN git clone --depth=1 https://github.com/bepass-org/warp-plus.git .
-
-ENV CGO_ENABLED=0
-ARG GIT_REF=manual
-RUN go build -v -o /out/ -trimpath \
-  -ldflags "-s -w -buildid= -checklinkname=0 -X main.version=${GIT_REF}" ./cmd/warp-plus && \
-    go build -v -o /out/ -trimpath \
-  -ldflags "-s -w -buildid= -checklinkname=0 -X main.version=${GIT_REF}" ./cmd/warp-scan
-
-# --- stage: runtime ---
 FROM alpine:3.20
 
-# Требуемые рантайм-пакеты: сертификаты, curl, jq, shuf (из coreutils), tzdata, libcap
-RUN apk add --no-cache ca-certificates curl jq coreutils tzdata libcap
+# Требуемые рантайм-пакеты: сертификаты, curl, jq, shuf (из coreutils), tzdata, libcap, tar
+RUN apk add --no-cache ca-certificates curl jq coreutils tzdata libcap tar
 
 # Система/права
 RUN mkdir -p /etc/warp/cache
 
-# Бинарники
-COPY --from=build /out/warp-plus /usr/bin/warp-plus
-COPY --from=build /out/warp-scan /usr/bin/warp-scan
+# Загрузка готовых бинарников
+ARG WARP_VERSION=0.0.0
+RUN curl -L -o /tmp/warp.tar.gz \
+    https://github.com/bepass-org/warp-plus/releases/download/${WARP_VERSION}/warp-plus_${WARP_VERSION}_linux_amd64.tar.gz \
+    && tar -xzf /tmp/warp.tar.gz -C /usr/bin warp-plus warp-scan \
+    && rm /tmp/warp.tar.gz
+
+# Права на бинарники
 RUN setcap CAP_NET_ADMIN,CAP_NET_RAW+eip /usr/bin/warp-plus \
     && setcap CAP_NET_ADMIN,CAP_NET_RAW+eip /usr/bin/warp-scan
 


### PR DESCRIPTION
## Summary
- drop Go build stage for warp Dockerfile and fetch release binaries directly
- fetch release archive in CI instead of cloning and build with version arg

## Testing
- `bash -n bin/warp/DockerEntrypoint.sh`
- `pip install yamllint` *(failed: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bdaf7f1c8325bb7767df1898cf17